### PR TITLE
bugfix: handle space on node link

### DIFF
--- a/slate_converter.go
+++ b/slate_converter.go
@@ -30,6 +30,7 @@ const (
 	_nodeTypeInline        = "inline"
 	_nodeTypeCaption       = "caption"
 	_nodeTypeFigure        = "figure"
+	_nodeTypeLink          = "link"
 )
 
 // SlateLeaf represents a text element with optional formatting.
@@ -103,6 +104,9 @@ func serializeSlateNodes(nodes []SlateNode, nodeSeparator, leaveSeparator string
 			case _nodeTypeInline:
 				modifiedSlateNodeSeparator = _spaceSeparator
 				result.WriteString(serializeSlateNodes(node.Nodes, modifiedSlateNodeSeparator, leaveSeparator) + leaveSeparator)
+			case _nodeTypeLink:
+				modifiedSlateNodeSeparator = _spaceSeparator
+				result.WriteString(serializeSlateNodes(node.Nodes, modifiedSlateNodeSeparator, leaveSeparator))
 			case _nodeTypeListItem:
 				modifiedSlateNodeSeparator = _commaSeparator
 				if node.isLastInList {

--- a/slate_converter_test.go
+++ b/slate_converter_test.go
@@ -22,3 +22,53 @@ RedMagic 10 Pro+ berada di posisi ketiga dengan skor AnTuTu 2.879.356, diikuti o
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
 }
+
+func Test_ToPlainText_Link(t *testing.T) {
+	t.Run("text link not contain space", func(t *testing.T) {
+		inputJSON := `{"document":{"nodes":[{"object":"block","type":"heading-large","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"ini adalah judul","marks":[]}]}]},{"object":"block","type":"paragraph","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"tanda kemunculan ","marks":[]}]},{"object":"inline","type":"link","data":{"href":"https://kumparan.com"},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"suzuki fronx","marks":[]}]}]},{"object":"text","leaves":[{"object":"leaf","text":" di indonesia.","marks":[]}]}]}]}}`
+		expected := `tanda kemunculan suzuki fronx di indonesia.`
+
+		input, err := ParseSlateDocument(inputJSON)
+		assert.NoError(t, err)
+
+		result, err := input.ToPlainText()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("text link include space on prefix", func(t *testing.T) {
+		inputJSON := `{"document":{"nodes":[{"object":"block","type":"heading-large","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"ini adalah judul","marks":[]}]}]},{"object":"block","type":"paragraph","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"tanda kemunculan","marks":[]}]},{"object":"inline","type":"link","data":{"href":"https://kumparan.com"},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":" suzuki fronx","marks":[]}]}]},{"object":"text","leaves":[{"object":"leaf","text":" di indonesia.","marks":[]}]}]}]}}`
+		expected := `tanda kemunculan suzuki fronx di indonesia.`
+
+		input, err := ParseSlateDocument(inputJSON)
+		assert.NoError(t, err)
+
+		result, err := input.ToPlainText()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("text link include space on suffix", func(t *testing.T) {
+		inputJSON := `{"document":{"nodes":[{"object":"block","type":"heading-large","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"ini adalah judul","marks":[]}]}]},{"object":"block","type":"paragraph","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"tanda kemunculan ","marks":[]}]},{"object":"inline","type":"link","data":{"href":"https://kumparan.com"},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"suzuki fronx ","marks":[]}]}]},{"object":"text","leaves":[{"object":"leaf","text":"di indonesia.","marks":[]}]}]}]}}`
+		expected := `tanda kemunculan suzuki fronx di indonesia.`
+
+		input, err := ParseSlateDocument(inputJSON)
+		assert.NoError(t, err)
+
+		result, err := input.ToPlainText()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("text link include space on prefix and suffix", func(t *testing.T) {
+		inputJSON := `{"document":{"nodes":[{"object":"block","type":"heading-large","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"ini adalah judul","marks":[]}]}]},{"object":"block","type":"paragraph","data":{},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":"tanda kemunculan","marks":[]}]},{"object":"inline","type":"link","data":{"href":"https://kumparan.com"},"nodes":[{"object":"text","leaves":[{"object":"leaf","text":" suzuki fronx ","marks":[]}]}]},{"object":"text","leaves":[{"object":"leaf","text":"di indonesia.","marks":[]}]}]}]}}`
+		expected := `tanda kemunculan suzuki fronx di indonesia.`
+
+		input, err := ParseSlateDocument(inputJSON)
+		assert.NoError(t, err)
+
+		result, err := input.ToPlainText()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+}


### PR DESCRIPTION
to handle when user create link include space on suffix/prefix the result is no space between the link and the before/next word
![image](https://github.com/user-attachments/assets/ad58253f-ffb4-4d59-8585-3903cdeabf0c)

the current result
Tanda kemunculanSuzuki Fronx di Indonesia

expected result
Tanda kemunculan Suzuki Fronx di Indonesia